### PR TITLE
Add wasm-strip to the container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,11 @@ FROM ghcr.io/swiftwasm/carton:latest
 LABEL maintainer="SwiftWasm Maintainers <hello@swiftwasm.org>"
 LABEL Description="Docker Container for the SwiftWasm toolchain and SDK"
 
+RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
+  apt-get -q install -y \
+  wabt && \
+  rm -r /var/lib/apt/lists/*
+
 COPY entrypoint.sh /entrypoint.sh
 
 # Code file to execute when the docker container starts up (`entrypoint.sh`)


### PR DESCRIPTION
The container image used by the GitHub action is based on the `carton` one. This image doesn't have `wasm-strip` anymore, because `carton` now provides stripping capabilities.

However, `wasm-strip` is still required by all the Swift Wasm projects that do not have the browser as a target.